### PR TITLE
Module ACM invocation bug fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,8 @@ module "acm" {
   create_certificate = "${var.certificate_arn == "" ? 1 : 0}"
 
   domain_name = "${var.acm_certificate_domain_name == "" ? join(".", list(var.name, var.route53_zone_name)) : var.acm_certificate_domain_name}"
-  zone_id     = "${data.aws_route53_zone.this.id}"
+
+  zone_id = "${var.certificate_arn == "" ? element(concat(data.aws_route53_zone.this.*.id, list("")), 0) : ""}"
 
   tags = "${local.tags}"
 }


### PR DESCRIPTION
Workaround to not error on accessing value on a data element that doesn't exist. 

```Error: Error running plan: 1 error(s) occurred:

* module.atlantis.module.acm.var.zone_id: Resource 'data.aws_route53_zone.this' not found for variable 'data.aws_route53_zone.this.id'
```

TODO:
Verify that workaround still works for creating certs with `aws_route53_zone` existing - DONE