### PR TITLE
add the ability to optionally encrypt cloudwatch logs and to manage t…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -192,6 +192,10 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
+  manage_default_security_group  = var.manage_default_security_group
+  default_security_group_ingress = var.default_security_group_ingress
+  default_security_group_egress  = var.default_security_group_egress
+
   tags = local.tags
 }
 
@@ -690,6 +694,7 @@ resource "aws_ecs_service" "atlantis" {
 resource "aws_cloudwatch_log_group" "atlantis" {
   name              = var.name
   retention_in_days = var.cloudwatch_log_retention_in_days
+  kms_key_id        = var.cloudwatch_logs_kms_key_id
 
   tags = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,24 @@ variable "azs" {
   default     = []
 }
 
+variable "manage_default_security_group" {
+  description = "Should be true to adopt and manage default security group"
+  type        = bool
+  default     = false
+}
+
+variable "default_security_group_ingress" {
+  description = "List of maps of ingress rules to set on the default security group"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "default_security_group_egress" {
+  description = "List of maps of egress rules to set on the default security group"
+  type        = list(map(string))
+  default     = []
+}
+
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC"
   type        = list(string)
@@ -217,6 +235,12 @@ variable "cloudwatch_log_retention_in_days" {
   description = "Retention period of Atlantis CloudWatch logs"
   type        = number
   default     = 7
+}
+
+variable "cloudwatch_logs_kms_key_id" {
+  description = "The ARN of the KMS Key to use when encrypting log data."
+  type        = string
+  default     = null
 }
 
 # SSM parameters for secrets


### PR DESCRIPTION
Trussworks fork of [terraform-aws-modules/terraform-aws-atlantis](https://github.com/terraform-aws-modules/terraform-aws-atlantis). Adding options to encrypt the atlantis cloudwatch log group and to close the default vpc security group to be compliant with MilMove Config rules.